### PR TITLE
Add custom seo block

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Content/Structure/SeoStructureExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Structure/SeoStructureExtension.php
@@ -43,6 +43,7 @@ class SeoStructureExtension extends AbstractExtension implements ExportExtension
         'noIndex',
         'noFollow',
         'hideInSitemap',
+        'customBlock'
     ];
 
     /**
@@ -67,6 +68,7 @@ class SeoStructureExtension extends AbstractExtension implements ExportExtension
         $this->saveProperty($node, $data, 'noIndex', false);
         $this->saveProperty($node, $data, 'noFollow', false);
         $this->saveProperty($node, $data, 'hideInSitemap', false);
+        $this->saveProperty($node, $data, 'customBlock', false);
     }
 
     /**
@@ -82,6 +84,7 @@ class SeoStructureExtension extends AbstractExtension implements ExportExtension
             'noIndex' => $this->loadProperty($node, 'noIndex', false),
             'noFollow' => $this->loadProperty($node, 'noFollow', false),
             'hideInSitemap' => $this->loadProperty($node, 'hideInSitemap', false),
+            'customBlock' => $this->loadProperty($node, 'customBlock', false),
         ];
     }
 

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
@@ -262,6 +262,10 @@
                 <source>sulu.content.seo.description</source>
                 <target>Beschreibung (Meta Description)</target>
             </trans-unit>
+            <trans-unit id="441d99ff2f64652633a5ca2169f22254" resname="sulu.content.seo.customBlock">
+                <source>sulu.content.seo.customBlock</source>
+                <target>Benutzerdefinierter Block</target>
+            </trans-unit>
             <trans-unit id="442d99ff2f64652633a5ca2169f22254" resname="sulu.content.seo.keywords">
                 <source>sulu.content.seo.keywords</source>
                 <target>Keywords (Meta Keywords)</target>
@@ -309,6 +313,10 @@
             <trans-unit id="c50af522ac181350142c0b4720e29a2f" resname="sulu.content.seo.descriptions.note">
                 <source>sulu.content.seo.descriptions.note</source>
                 <target>Die Meta-Beschreibung ist auf 155 Zeichen limitiert.</target>
+            </trans-unit>
+            <trans-unit id="c50af522ac181350142c0b4720e29a2f" resname="sulu.content.seo.customBlock.note">
+                <source>sulu.content.seo.customBlock.note</source>
+                <target>This block is added as is in head section</target>
             </trans-unit>
             <trans-unit id="e50af522ac181350142c0b4720e29a2f" resname="sulu.content.seo.characters-left">
                 <source>sulu.content.seo.characters-left</source>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
@@ -262,6 +262,10 @@
                 <source>sulu.content.seo.description</source>
                 <target>Description (Meta Description)</target>
             </trans-unit>
+            <trans-unit id="441d99ff2f64652633a5ca2169f22254" resname="sulu.content.seo.customBlock">
+                <source>sulu.content.seo.customBlock</source>
+                <target>Custom Block</target>
+            </trans-unit>
             <trans-unit id="442d99ff2f64652633a5ca2169f22254" resname="sulu.content.seo.keywords">
                 <source>sulu.content.seo.keywords</source>
                 <target>Keywords (Meta Keywords)</target>
@@ -321,6 +325,10 @@
             <trans-unit id="c50af522ac181350142c0b4720e29a2f" resname="sulu.content.seo.descriptions.note">
                 <source>sulu.content.seo.descriptions.note</source>
                 <target>The meta description is limited to 155 characters.</target>
+            </trans-unit>
+            <trans-unit id="c50af522ac181350142c0b4720e29a2f" resname="sulu.content.seo.customBlock.note">
+                <source>sulu.content.seo.customBlock.note</source>
+                <target>This block is added as is in head section</target>
             </trans-unit>
             <trans-unit id="a945ccdbf95d2852ab6390cea24ebb6f" resname="content.contents.title">
                 <source>content.contents.title</source>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.fr.xlf
@@ -262,6 +262,10 @@
                 <source>sulu.content.seo.description</source>
                 <target>Description (Meta Description)</target>
             </trans-unit>
+            <trans-unit id="441d99ff2f64652633a5ca2169f22254" resname="sulu.content.seo.customBlock">
+                <source>sulu.content.seo.customBlock</source>
+                <target>Bloc personnalisé</target>
+            </trans-unit>
             <trans-unit id="442d99ff2f64652633a5ca2169f22254" resname="sulu.content.seo.keywords">
                 <source>sulu.content.seo.keywords</source>
                 <target>Mots-clefs (Meta Keywords)</target>
@@ -321,6 +325,10 @@
             <trans-unit id="c50af522ac181350142c0b4720e29a2f" resname="sulu.content.seo.descriptions.note">
                 <source>sulu.content.seo.descriptions.note</source>
                 <target>La meta description est limitée à 155 caractères.</target>
+            </trans-unit>
+            <trans-unit id="c50af522ac181350142c0b4720e29a2f" resname="sulu.content.seo.customBlock.note">
+                <source>sulu.content.seo.customBlock.note</source>
+                <target>This block is added as is in head section</target>
             </trans-unit>
             <trans-unit id="a945ccdbf95d2852ab6390cea24ebb6f" resname="content.contents.title">
                 <source>content.contents.title</source>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.nl.xlf
@@ -262,6 +262,10 @@
                 <source>sulu.content.seo.description</source>
                 <target>Beschrijving (Meta description)</target>
             </trans-unit>
+            <trans-unit id="441d99ff2f64652633a5ca2169f22254" resname="sulu.content.seo.customBlock">
+                <source>sulu.content.seo.customBlock</source>
+                <target>Aangepast blokje</target>
+            </trans-unit>
             <trans-unit id="442d99ff2f64652633a5ca2169f22254" resname="sulu.content.seo.keywords">
                 <source>sulu.content.seo.keywords</source>
                 <target>Keywords (Meta Keywords)</target>
@@ -321,6 +325,10 @@
             <trans-unit id="c50af522ac181350142c0b4720e29a2f" resname="sulu.content.seo.descriptions.note">
                 <source>sulu.content.seo.descriptions.note</source>
                 <target>De meta-beschrijving is gelimiteerd tot 155 karakters.</target>
+            </trans-unit>
+            <trans-unit id="c50af522ac181350142c0b4720e29a2f" resname="sulu.content.seo.customBlock.note">
+                <source>sulu.content.seo.customBlock.note</source>
+                <target>This block is added as is in head section</target>
             </trans-unit>
             <trans-unit id="a945ccdbf95d2852ab6390cea24ebb6f" resname="content.contents.title">
                 <source>content.contents.title</source>

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/seo.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/seo.html.twig
@@ -51,6 +51,15 @@
         <input type="text" id="seo-canonical" data-mapper-property="canonicalUrl"
                class="form-element preview-update trigger-save-button"/>
     </div>
+    <div class="grid-row form-group">
+        <label for="seo-customBlock"><%=translate('sulu.content.seo.customBlock')%></label>
+        <textarea id="seo-customBlock" data-mapper-property="customBlock"
+                  class="form-element preview-update trigger-save-button"></textarea>
+
+        <span class="smaller-font grey-font">
+            <%= translate('sulu.content.seo.customBlock.note')%>
+        </span>
+    </div>
     <div class="form-group grid-row">
         <label><%=translate('sulu.content.seo.robots')%></label>
 

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceTest.php
@@ -158,6 +158,7 @@ class WebspaceTest extends SuluTestCase
                     'noIndex' => '0',
                     'noFollow' => '1',
                     'hideInSitemap' => '1',
+                    'customBlock' => 'Seo Custom Block1',
                 ],
                 'excerpt' => [
                     'title' => 'Excerpt Test1',
@@ -178,6 +179,7 @@ class WebspaceTest extends SuluTestCase
                     'noIndex' => '1',
                     'noFollow' => '0',
                     'hideInSitemap' => '1',
+                    'customBlock' => 'Seo Custom Block2',
                 ],
                 'excerpt' => [
                     'title' => 'Excerpt Test2',
@@ -312,6 +314,12 @@ class WebspaceTest extends SuluTestCase
                         '',
                         false,
                         $extensionData['seo']['hideInSitemap']
+                    ),
+                    'customBlock' => $this->createItemArray(
+                        'customBlock',
+                        '',
+                        true,
+                        $extensionData['seo']['customBlock']
                     ),
                 ],
                 'excerpt' => [

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Structure/SeoStructureExtensionTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Structure/SeoStructureExtensionTest.php
@@ -58,6 +58,7 @@ class SeoStructureExtensionTest extends \PHPUnit_Framework_TestCase
             'noIndex' => true,
             'noFollow' => true,
             'hideInSitemap' => true,
+            'customBlock' => 'Custom Block',
         ];
         $this->extension->setLanguageCode('de', 'i18n', null);
         $this->extension->save($this->node->reveal(), $data, 'default', 'de');
@@ -113,6 +114,7 @@ class SeoStructureExtensionTest extends \PHPUnit_Framework_TestCase
             'noIndex' => true,
             'noFollow' => true,
             'hideInSitemap' => true,
+            'customBlock' => 'Custom Block',
         ];
 
         $content = [
@@ -178,6 +180,7 @@ class SeoStructureExtensionTest extends \PHPUnit_Framework_TestCase
                 'noIndex' => false,
                 'noFollow' => false,
                 'hideInSitemap' => false,
+                'customBlock' => '',
             ],
             $result
         );

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
@@ -13,6 +13,7 @@
 {% set seoTitle = seo.title|default(content.title|default()) %}
 {% set seoDescription = seo.description|default() %}
 {% set seoKeywords = seo.keywords|default() %}
+{% set seoCustomBlock = seo.customBlock|default() %}
 
 {% set seoRobots = '' %}
 {%- if seo.noIndex|default(false) -%}
@@ -73,4 +74,11 @@
 {%- block canonical -%}
     {#- Set canonical to itself if a bot clone the page -#}
     <link rel="canonical" href="{{ seoCanonical|default(app.request.uri) }}"/>
+{%- endblock -%}
+
+
+{%- block customBlock -%}
+
+        {{ seoCustomBlock | raw }}
+
 {%- endblock -%}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
@@ -157,6 +157,7 @@ class SeoTwigExtensionTest extends \PHPUnit_Framework_TestCase
                     'noIndex' => true,
                     'noFollow' => true,
                     'hideInSitemap' => true,
+                    'customBlock' => 'Custom Block',
                 ],
                 [
                     'title' => 'Content title',
@@ -188,6 +189,7 @@ class SeoTwigExtensionTest extends \PHPUnit_Framework_TestCase
                     'noIndex' => false,
                     'noFollow' => false,
                     'hideInSitemap' => true,
+                    'customBlock' => '',
                 ],
                 [
                     'title' => 'Content title',
@@ -221,6 +223,7 @@ class SeoTwigExtensionTest extends \PHPUnit_Framework_TestCase
                     'noIndex' => false,
                     'noFollow' => false,
                     'hideInSitemap' => true,
+                    'customBlock' => '',
                 ],
                 [
                     'title' => 'Content title',
@@ -254,6 +257,7 @@ class SeoTwigExtensionTest extends \PHPUnit_Framework_TestCase
                     'noIndex' => false,
                     'noFollow' => false,
                     'hideInSitemap' => true,
+                    'customBlock' => '',
                 ],
                 [
                     'title' => 'Content title',
@@ -383,6 +387,7 @@ class SeoTwigExtensionTest extends \PHPUnit_Framework_TestCase
                     'noIndex' => true,
                     'noFollow' => true,
                     'hideInSitemap' => true,
+                    'customBlock' => 'Custom Block',
                 ],
                 [
                     'title' => 'Content title',
@@ -417,6 +422,7 @@ class SeoTwigExtensionTest extends \PHPUnit_Framework_TestCase
                     'title' => '"SEO title"',
                     'description' => '"SEO description"',
                     'keywords' => '"SEO keywords"',
+                    'customBlock' => '"Custom Block"',
                 ],
                 [],
                 [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum



New custom seo block. Is added in head section as it is

